### PR TITLE
在minist demo中要求python版本为3.6

### DIFF
--- a/example/mnist_demo/README.md
+++ b/example/mnist_demo/README.md
@@ -34,6 +34,7 @@ cp pywrap_dlopen_global_flags.py fl-env/lib/python3.6/site-packages/tensorflow_c
 ```
 
 如果不打算使用virutalenv, 请确保tensorflow版本为1.15且protobuf版本为3.8.0.
+
 然后下载[pywrap_dlopen_global_flags.py](https://github.com/tensorflow/tensorflow/blob/r1.15/tensorflow/python/pywrap_dlopen_global_flags.py)并拷贝到tensorflow目录, 例如`site-packages/tensorflow_core/python/`
 
 2. 运行mnist demo
@@ -69,6 +70,7 @@ grep loss logs/leader.log
 编译和部署proxy参见[src/Proxy/README.md](../../src/Proxy/README.md)
 
 需要修改redis配置和对端proxy配置, 默认对端请求监听8001端口,
+
 redis默认使用6379端口
 
 默认同侧请求监听8002端口, 日志在src/Proxy/logs

--- a/example/mnist_demo/README.md
+++ b/example/mnist_demo/README.md
@@ -10,7 +10,7 @@ cp -r ../../src/Trainer/fl_comm_libs .
 ```
 
 #### 单机版
-1. 准备python3环境
+1. 准备python3.6环境(推荐python3.6.8)
 
 我们推荐使用`virtualenv`来避免python相关的环境问题
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 setuptools==41.0.0
+grpcio==1.26.0
+grpcio-tools==1.26.0
 tensorflow==1.15.0
 protobuf==3.8.0
 redis==3.0.1
 jinja2
 yappi
-grpcio
-grpcio-tools
 Flask==1.0.2
 requests
 peewee==3.9.3


### PR DESCRIPTION
python3.7 运行mnist demo会出core
修改成python 3.6.8 搭配 grpcio版本为1.26.0或1.32.0均可